### PR TITLE
Added check to omit null values from the getConfigMap generator. 

### DIFF
--- a/src/main/io.github.config4k/GetConfigMap.kt
+++ b/src/main/io.github.config4k/GetConfigMap.kt
@@ -7,12 +7,15 @@ import kotlin.reflect.full.primaryConstructor
 
 internal fun getConfigMap(receiver: Any,
                           clazz: KClass<Any>): Map<String, *> =
-        clazz.primaryConstructor!!.parameters.map {
+        clazz.primaryConstructor!!.parameters.mapNotNull {
             val parameterName = it.name!!
-            parameterName to clazz.memberProperties
+            clazz.memberProperties
                     .find { it.name == parameterName }!!
                     .get(receiver)
-                    ?.toConfigValue()
+                    ?.let {parameterValue  ->
+                        parameterName to parameterValue.toConfigValue()
+                    }
+
         }.toMap()
 
 internal fun Any.toConfigValue(): ConfigValue {

--- a/src/test/io/github/config4k/TestNullable.kt
+++ b/src/test/io/github/config4k/TestNullable.kt
@@ -18,5 +18,26 @@ class TestNullable : WordSpec() {
                 config.extract<Int?>("key") shouldBe null
             }
         }
+
+        "Any.toConfig" should {
+            "omit null values from the config"{
+                val complete = PartialData(path1 = "complete",path2 = "complete").toConfig("data")
+                complete.hasPath("data.path1") shouldBe true
+                complete.hasPath("data.path2") shouldBe true
+
+                val partial = PartialData(path1 = "partial").toConfig("data")
+                partial.hasPath("data.path1") shouldBe true
+                partial.hasPath("data.path2") shouldBe false
+
+                val merged = partial.withFallback(complete)
+                merged.hasPath("data.path1") shouldBe true
+                merged.hasPath("data.path2") shouldBe true
+
+                merged.getString("data.path1") shouldBe "partial"
+                merged.getString("data.path2") shouldBe "complete"
+            }
+        }
     }
 }
+
+data class PartialData(var path1: String?= null, var path2: String? = null)


### PR DESCRIPTION
Currently, it would map the property to the string "null", which is probably not the intent. 

