### PR TITLE
Add support for hyphenated paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 #IntelliJ IDEA
 .idea
+*.iml
+*.ipr
 #Gradle
 .gradle
 build/
 gradle.properties
+out/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.2.60'
     repositories {
         mavenCentral()
         jcenter()
@@ -29,6 +29,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile 'com.typesafe:config:1.3.3'
+    compile 'com.google.guava:guava:26.0-jre'
     testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.8'
 }
 

--- a/src/main/io.github.config4k/TypeReference.kt
+++ b/src/main/io.github.config4k/TypeReference.kt
@@ -1,7 +1,6 @@
 package io.github.config4k
 
 
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
@@ -24,8 +23,9 @@ data class ClassContainer(val mapperClass: KClass<*>, val typeArguments: List<Cl
 internal fun getGenericList(type: ParameterizedType): List<ClassContainer> {
     return type.actualTypeArguments.toList().map { r ->
         val impl = if (r is WildcardType) r.upperBounds[0] else r
-        val wild = (if (impl is ParameterizedTypeImpl) impl.rawType else impl as Class<*>).kotlin
-        if (impl is ParameterizedTypeImpl) ClassContainer(wild, getGenericList(impl))
+        val wild = (if (impl is ParameterizedType) impl.rawType as Class<*> else impl as Class<*>)
+            .kotlin
+        if (impl is ParameterizedType) ClassContainer(wild, getGenericList(impl))
         else ClassContainer(wild)
     }
 }

--- a/src/main/io.github.config4k/readers/SelectReader.kt
+++ b/src/main/io.github.config4k/readers/SelectReader.kt
@@ -28,7 +28,7 @@ object SelectReader {
     fun getReader(clazz: ClassContainer): (Config, String)->Any? {
         for (customType in customTypeRegistry) {
             if (customType.testParse(clazz)) {
-                return Reader({ config, name -> customType.parse(clazz, config, name) }).getValue
+                return Reader { config, name -> customType.parse(clazz, config, name) }.getValue
             }
         }
         return when (clazz.mapperClass) {

--- a/src/test/io/github/config4k/TestArbitraryType.kt
+++ b/src/test/io/github/config4k/TestArbitraryType.kt
@@ -60,6 +60,20 @@ class TestArbitraryType : WordSpec({
                 wholeConfig shouldBe WholeConfig(Person("foo", 20))
             }
         }
+
+    "Config.extract<NestHyphenated>()" should {
+        "return NestHyphenated without path" {
+            val config = """
+                    {
+                      nested-person = {
+                         name = "foo"
+                         age = 20
+                       }
+                    }""".toConfig()
+            val nestHyphenated = config.extract<NestHyphenated>()
+            nestHyphenated shouldBe NestHyphenated(Person("foo", 20))
+        }
+    }
 })
 
 data class Person(val name: String, val age: Int? = 10)
@@ -67,3 +81,4 @@ data class Person(val name: String, val age: Int? = 10)
 data class Nest(val nest: Int, val person: Person)
 
 data class WholeConfig(val key: Person)
+data class NestHyphenated(val nestedPerson: Person)


### PR DESCRIPTION
Right now you cannot extract config where the path is actually hyphenated in the config ex. you have a property `nestedObject` but in your configuration it is specified as `nested-object`. This is because the path is specified using reflection from the object property names.

The easy fix for this is just to try the current property name first and if nothing is found try hyphenated case before returning null.