### PR TITLE
convert to a java library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 }
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'jacoco'
 apply plugin: 'com.novoda.bintray-release'
@@ -26,11 +26,11 @@ test {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile 'com.typesafe:config:1.3.3'
-    compile 'com.google.guava:guava:26.0-jre'
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    api 'com.typesafe:config:1.3.3'
+    implementation 'com.google.guava:guava:26.0-jre'
+    testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.1.8'
 }
 
 sourceSets {


### PR DESCRIPTION
- this way the classpath of projects are not filled with possible outdated kotlin or guava library