### PR TITLE
 Add functionality to define arbitrary map keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ dependencies {
 ## Usage
 ### Deserialization
 `Config.extract<T>` converts `Config` to `T`.
+#### Map
+Maps can be serialized with `String` keys
+```kotlin
+val config = ConfigFactory.parseString("""
+                                          |map {  
+                                          |  foo = 5
+                                          |  bar = 6
+                                          |}""".trimMargin())
+val person: Map<String, Int> = config.extract<Map<String, Int>>("map")
+map["foo"] == 5 // true
+map["bar"] == 6 // true
+```
+or with arbitrary keys
+```kotlin
+val config = ConfigFactory.parseString("""
+                                          |map [{  
+                                          |  key = 5
+                                          |  value = "foo"
+                                          |}
+                                          |{
+                                          |  key = 6
+                                          |  value = "bar"
+                                          |}]""".trimMargin())
+val person: Map<Int, String> = config.extract<Map<Int, String>>("map")
+map[5] == "foo" // true
+map[6] == "bar" // true
+```
+Test Class: [TestMap.kt](https://github.com/config4k/config4k/blob/master/src/test/io/github/config4k/TestMap.kt)
 #### Data Classes
 Config4k has no option to use different names between code and config file.
 ```kotlin
@@ -166,7 +194,7 @@ person {
 - Collections
     - `List`
     - `Set`
-    - `Map<String, T>`
+    - `Map<K, V>`
     - `Array<T>` (You can use `Array<Int>`, but can't use `Array<Array<Int>>`)
 - Nullable `T?`
 - Typesafe Config classes(Calling `toConfig` is meaningless)

--- a/src/main/io.github.config4k/Extension.kt
+++ b/src/main/io.github.config4k/Extension.kt
@@ -71,13 +71,18 @@ fun Any.toConfig(name: String): Config {
             mapOf(name to list)
         }
         this is Map<*, *> -> {
-            val map = this.mapKeys {
-                (it.key as? String) ?:
-                        throw Config4kException.UnSupportedType(clazz)
-            }.mapValues {
-                it.value?.toConfigValue()?.unwrapped()
+            val stringKeys = this.keys.all { it is String }
+            if (stringKeys) {
+                val map = this.mapKeys { it.key as String }.mapValues {
+                    it.value?.toConfigValue()?.unwrapped()
+                }
+                mapOf(name to map)
+            }else{
+                val list = this.map { (key, value) ->
+                    MapEntry(key, value).toConfigValue()
+                }
+                mapOf(name to list)
             }
-            mapOf(name to map)
         }
         clazz.primaryConstructor != null ->
             mapOf(name to getConfigMap(this, clazz))

--- a/src/main/io.github.config4k/GetConfigMap.kt
+++ b/src/main/io.github.config4k/GetConfigMap.kt
@@ -22,3 +22,5 @@ internal fun Any.toConfigValue(): ConfigValue {
     val name = "dummy"
     return this.toConfig(name).root()[name]!!
 }
+
+internal data class MapEntry<K, V>(val key: K, val value: V)

--- a/src/main/io.github.config4k/readers/MapReader.kt
+++ b/src/main/io.github.config4k/readers/MapReader.kt
@@ -1,13 +1,23 @@
 package io.github.config4k.readers
 
 import io.github.config4k.ClassContainer
+import io.github.config4k.MapEntry
 
-
-internal class MapReader(clazz: ClassContainer) : Reader<Map<String, *>>({
+internal class MapReader(keyClass: ClassContainer, valueClass: ClassContainer) : Reader<Map<*, *>?>({
     config, path ->
-    val child = config.getConfig(path)
-    child.root().entries.map {
-        val key = it.key
-        key to SelectReader.getReader(clazz)(child, key)
-    }.toMap()
+    when(keyClass.mapperClass){
+        String::class ->{
+            val child = config.getConfig(path)
+            child.root().keys.associate{ key ->
+                key to SelectReader.getReader(valueClass)(child, key)
+            }
+        }
+        else -> {
+            val mapEntryClassContainer = ClassContainer(MapEntry::class, mapOf("K" to keyClass, "V" to valueClass))
+            ListReader(mapEntryClassContainer).getValue(config, path)?.associate {
+                val mapEntry = it as MapEntry<*,*>
+                mapEntry.key to mapEntry.value
+            }
+        }
+    }
 })

--- a/src/main/io.github.config4k/readers/SelectReader.kt
+++ b/src/main/io.github.config4k/readers/SelectReader.kt
@@ -46,7 +46,7 @@ object SelectReader {
             ConfigValue::class -> ConfigValueReader()
             List::class -> ListReader(clazz.typeArguments.getValue("E"))
             Set::class -> SetReader(clazz.typeArguments.getValue("E"))
-            Map::class -> MapReader(clazz.typeArguments.getValue("V"))
+            Map::class -> MapReader(clazz.typeArguments.getValue("K"), clazz.typeArguments.getValue("V"))
             File::class -> FileReader()
             Path::class -> PathReader()
             else ->

--- a/src/test/io/github/config4k/TestArbitraryGenericType.kt
+++ b/src/test/io/github/config4k/TestArbitraryGenericType.kt
@@ -90,7 +90,7 @@ class TestArbitraryGenericType : WordSpec({
         }
     }
 
-    "Config.extract<PetPerson<HungrySnake<Mouse>, Cat>>" should {
+    "Config.extract<PetPerson<HungrySnake<Mouse>>>" should {
         "return PetPerson" {
             val config = """
                 key = {

--- a/src/test/io/github/config4k/TestMap.kt
+++ b/src/test/io/github/config4k/TestMap.kt
@@ -45,5 +45,19 @@ class TestMap : WordSpec({
             val list = mapConfig.extract<Map<String, List<Int>>>("nest")
             list shouldBe mapOf("key1" to listOf(0, 1), "key2" to listOf(2, 3))
         }
+
+        "return Map<Int, String>" {
+            val mapConfig = """
+                        nest = [{
+                          key = 10
+                          value = "dogs"
+                        },
+                        {
+                          key = 20
+                          value = "cats"
+                        }]""".toConfig()
+            val list = mapConfig.extract<Map<Int, String>>("nest")
+            list shouldBe mapOf(10 to "dogs", 20 to "cats")
+        }
     }
 })

--- a/src/test/io/github/config4k/TestToConfigForArbitraryGenericType.kt
+++ b/src/test/io/github/config4k/TestToConfigForArbitraryGenericType.kt
@@ -28,4 +28,18 @@ class TestToConfigForArbitraryGenericType : WordSpec({
                     Cat(7))
         }
     }
+
+    "PetPerson<HungrySnake<Mouse>>.toConfig" should {
+        "return Config having PetPerson<Mouse>" {
+            val person = PetPerson("bar", 42, HungrySnake(3, listOf(Mouse("foobar")))).toConfig("person")
+            person.extract<PetPerson<HungrySnake<Mouse>>>("person") shouldBe PetPerson("bar", 42, HungrySnake(3, listOf(Mouse("foobar"))))
+        }
+    }
+
+    "TwoPetSwapPerson<Dog, Cat>.toConfig" should {
+        "return Config having TwoPetSwapPerson<Dog, Cat>" {
+            val person = TwoPetSwapPerson("Jon", 21, Cat(9), Dog("woof")).toConfig("person")
+            person.extract<TwoPetSwapPerson<Dog, Cat>>("person") shouldBe TwoPetSwapPerson("Jon", 21, Cat(9), Dog("woof"))
+        }
+    }
 })

--- a/src/test/io/github/config4k/TestToConfigForCollection.kt
+++ b/src/test/io/github/config4k/TestToConfigForCollection.kt
@@ -22,4 +22,14 @@ class TestToConfigForCollection : WordSpec({
                     .extract<Map<String, Person>>("map") shouldBe map
         }
     }
+
+    "Map<Int, Person>.toConfig" should {
+        "return Config having Map<Int, Person>" {
+            val map = mapOf(
+                    7 to Person("Jon", 12),
+                    20 to Person("Doe", 15))
+            map.toConfig("map")
+                    .extract<Map<Int, Person>>("map") shouldBe map
+        }
+    }
 })


### PR DESCRIPTION
- maps with String keys are converted and read as before
- maps with other key types are converted and read as lists of MapEntry (`src/main/io.github.config4k/GetConfigMap.kt`)