### PR TITLE
Config can be a Property Delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/config4k/config4k.svg?branch=master)](https://travis-ci.org/config4k/config4k) [![codecov](https://codecov.io/gh/config4k/config4k/branch/master/graph/badge.svg)](https://codecov.io/gh/config4k/config4k) [![codebeat badge](https://codebeat.co/badges/4e9682a1-cdbb-4e1f-804b-a2d801381942)](https://codebeat.co/projects/github-com-config4k-config4k) [![kotlin](https://img.shields.io/badge/kotlin-1.3.10-pink.svg)]() [ ![Download](https://api.bintray.com/packages/config4k/config4k/config4k/images/download.svg) ](https://bintray.com/config4k/config4k/config4k/_latestVersion)
 
-_**Config** for **K**otlin._  
+_**Config** for **K**otlin._
 
 **Config4k** is a lightweight [Typesafe Config](https://github.com/typesafehub/config) wrapper for Kotlin and inspired by [ficus](https://github.com/iheartradio/ficus),  providing simple extension functions `Config.extract<T>` and `Any.toConfig` to convert between `Config` and Kotlin Objects.
 
@@ -187,14 +187,20 @@ person {
 ```
 
 ## Supported types
-`extract` and `toConfig` support these types.
+Property delegation, `extract` and `toConfig` support these types:
 - Primitive types
      - `Boolean`
+     - `Byte`
      - `Int`
      - `Long`
+     - `Float`
      - `Double`
 - `String`
+- `import java.io.File`
+- `import java.nio.file.Path`
 - `java.time.Duration`
+- `java.time.Period`
+- `java.time.temporal.TemporalAmount`
 - `kotlin.text.Regex`
 - Collections
     - `List`
@@ -205,8 +211,11 @@ person {
 - Typesafe Config classes(Calling `toConfig` is meaningless)
     - `com.typesafe.config.Config`
     - `com.typesafe.config.ConfigValue`
+    - `com.typesafe.config.ConfigMemorySize`
 - Enum
 - Data classes
+
+See [SelectReader.kt](src/main/io.github.config4k/readers/SelectReader.kt) for the exhaustive list.
 
 ## Contribute
 Would you like to contribute to Config4k?  

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ val config = ConfigFactory.parseString("""
                                           |  foo = 5
                                           |  bar = 6
                                           |}""".trimMargin())
-val person: Map<String, Int> = config.extract<Map<String, Int>>("map")
-map["foo"] == 5 // true
-map["bar"] == 6 // true
+val map: Map<String, Int> = config.extract<Map<String, Int>>("map")
+println(map["foo"] == 5) // true
+println(map["bar"] == 6) // true
 ```
 or with arbitrary keys
 ```kotlin
 val config = ConfigFactory.parseString("""
-                                          |map [{  
+                                          |map = [{  
                                           |  key = 5
                                           |  value = "foo"
                                           |}
@@ -60,9 +60,9 @@ val config = ConfigFactory.parseString("""
                                           |  key = 6
                                           |  value = "bar"
                                           |}]""".trimMargin())
-val person: Map<Int, String> = config.extract<Map<Int, String>>("map")
-map[5] == "foo" // true
-map[6] == "bar" // true
+val map: Map<Int, String> = config.extract<Map<Int, String>>("map")
+println(map[5] == "foo") // true
+println(map[6] == "bar") // true
 ```
 Test Class: [TestMap.kt](https://github.com/config4k/config4k/blob/master/src/test/io/github/config4k/TestMap.kt)
 #### Data Classes
@@ -76,8 +76,8 @@ val config = ConfigFactory.parseString("""
                                           |  age = 20
                                           |}""".trimMargin())
 val person: Person = config.extract<Person>("key")
-person.name == "foo" // true
-person.age == 20 // true
+println(person.name == "foo") // true
+println(person.age == 20) // true
 ```
 For more details, please see [TestArbitraryType.kt](https://github.com/config4k/config4k/blob/master/src/test/io/github/config4k/TestArbitraryType.kt)
 #### Nullable
@@ -87,8 +87,8 @@ Using `extract<T?>` is the better way than `Config.hasPath()`.
 val config = ConfigFactory.parseString("""key = 10""")
 val key = config.extract<Int?>("key")
 val foo = config.extract<Int?>("foo")
-key == 10 // true
-foo == null // true
+println(key == 10) // true
+println(foo == null) // true
 ```
 Test Class: [TestNullable.kt](https://github.com/config4k/config4k/blob/master/src/test/io/github/config4k/TestNullable.kt)
 #### Enum
@@ -102,7 +102,7 @@ enum class Size {
 
 val config = ConfigFactory.parseString("""key = SMALL""")
 val small = config.extract<Size>("key")
-small == Size.SMALL // true
+println(small == Size.SMALL) // true
 ```
 Test Class: [TestEnum.kt](https://github.com/config4k/config4k/blob/master/src/test/io/github/config4k/TestEnum.kt)
 ### Serialization
@@ -112,7 +112,7 @@ You can use [ConfigValue.render()](https://typesafehub.github.io/config/latest/a
 ```kotlin
 data class Person(val name: String, val age: Int)
 val person = Person("foo", 20).toConfig("person")
-println(person.root().render())               
+println(person.root().render())
 ```
 Output:
 ```
@@ -131,8 +131,10 @@ Test Class: [TestToConfigForArbitraryType.kt](https://github.com/config4k/config
 Typesafe Config's class `ConfigRenderOptions` is the argument of `ConfigValue.render`.
 ```kotlin
 // If setJson(false) is called, ConfigValue.render returns HOCON
+data class Person(val name: String, val age: Int)
+val person = Person("foo", 20).toConfig("person")
 val options = ConfigRenderOptions.defaults().setJson(false)
-println(person.root().render(option))
+println(person.root().render(options))
 ```
 Output:
 ```
@@ -147,10 +149,12 @@ person {
 
 ```kotlin
 // setOriginComments(false) removes comments
+data class Person(val name: String, val age: Int)
+val person = Person("foo", 20).toConfig("person")
 val options = ConfigRenderOptions.defaults()
                         .setJson(false)
                         .setOriginComments(false)
-println(person.root().render(option))
+println(person.root().render(options))
 ```
 Output:
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ _**Config** for **K**otlin._
 ## Table of Contents
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Delegated Properties](#delegated-properties)
   - [Deserialization](#deserialization)
     - [Data Classes](#data-classes)
     - [Nullable](#nullable)
@@ -35,6 +36,27 @@ dependencies {
 }
 ```
 ## Usage
+
+### Delegated Properties
+
+By far the simplest way to use config4k is via [Kotlin Delegated Properties](https://kotlinlang.org/docs/reference/delegated-properties.html):
+
+```kotlin
+val config = ConfigFactory.parseString("""
+                                          |stringValue = hello
+                                          |booleanValue = true
+                                          |""".trimMargin())
+
+val stringValue: String by config
+println(stringValue) // hello
+
+val nullableStringValue: String? by config
+println(nullableStringValue) // null
+
+val booleanValue: Boolean by config
+println(booleanValue) // true
+```
+
 ### Deserialization
 `Config.extract<T>` converts `Config` to `T`.
 #### Map

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,14 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     api 'com.typesafe:config:1.3.3'
     testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.1.8'
+    testImplementation 'com.atlassian.commonmark:commonmark:0.13.1'
+
+    testImplementation "org.jetbrains.kotlin:kotlin-script-util:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ sourceSets {
     test.kotlin.srcDirs += 'src/test'
 }
 
+jacoco {
+    toolVersion = "0.8.5"
+}
+
 jacocoTestReport {
     reports {
         html.enabled = false

--- a/src/test/io/github/config4k/TestDocumentedExamples.kt
+++ b/src/test/io/github/config4k/TestDocumentedExamples.kt
@@ -24,10 +24,18 @@ class TestDocumentedExamples : StringSpec({
                 """.trimIndent())
             }
 
-            output.nonBlankTrimmedLines() shouldBe expected.nonBlankTrimmedLines()
+            output.lines().sanitized() shouldBe expected.lines().sanitized()
         }
     }
 })
+
+private fun List<String>.sanitized(): List<String> = this
+        // ignore leading spaces since expected outputs derived from comments may have them
+        .map { it.trim() }
+        // ignore warnings that Java 13 injects into actual output
+        .filterNot { it.startsWith("warning: ")}
+        // ignore trailing newline
+        .dropLastWhile { it.isBlank() }
 
 private val engine = KotlinJsr223JvmLocalScriptEngineFactory()
         .scriptEngine
@@ -91,5 +99,3 @@ private fun outputOf(block: () -> Unit): String {
         System.setOut(out)
     }
 }
-
-private fun String.nonBlankTrimmedLines(): List<String> = lines().map { it.trim() }.filter { it.isNotBlank() }

--- a/src/test/io/github/config4k/TestDocumentedExamples.kt
+++ b/src/test/io/github/config4k/TestDocumentedExamples.kt
@@ -84,6 +84,7 @@ private fun outputOf(block: () -> Unit): String {
         System.setOut(PrintStream(bytes))
 
         block.invoke()
+        System.out.flush()
 
         return bytes.toString("UTF-8")
     } finally {

--- a/src/test/io/github/config4k/TestDocumentedExamples.kt
+++ b/src/test/io/github/config4k/TestDocumentedExamples.kt
@@ -1,0 +1,94 @@
+package io.github.config4k
+
+import io.kotlintest.data.forall
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.kotlintest.tables.Row3
+import org.commonmark.node.AbstractVisitor
+import org.commonmark.node.FencedCodeBlock
+import org.commonmark.parser.Parser
+import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngineFactory
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+class TestDocumentedExamples : StringSpec({
+    "examples should compile and run with expected output" {
+        forall(*examples()) { _, script, expected ->
+            val output = outputOf {
+                engine.eval("""
+                    import com.typesafe.config.*
+                    import io.github.config4k.*
+
+                    $script
+                """.trimIndent())
+            }
+
+            output.nonBlankTrimmedLines() shouldBe expected.nonBlankTrimmedLines()
+        }
+    }
+})
+
+private val engine = KotlinJsr223JvmLocalScriptEngineFactory()
+        .scriptEngine
+
+private fun examples(): Array<Row3<String, String, String>> = File("README.md")
+        .fencedCodeBlocks()
+        .groupedByCodeSample()
+        .toRows()
+        .filter { (lang, _, _) -> lang == "kotlin" }
+        .toTypedArray()
+
+private fun File.fencedCodeBlocks(): List<FencedCodeBlock> = readText()
+        .let { text ->
+            mutableListOf<FencedCodeBlock>()
+                    .also { blocks ->
+                        Parser.builder().build().parse(text).accept(object : AbstractVisitor() {
+                            override fun visit(fencedCodeBlock: FencedCodeBlock) {
+                                blocks += fencedCodeBlock
+                            }
+                        })
+                    }
+        }
+
+private fun List<FencedCodeBlock>.groupedByCodeSample(): List<List<FencedCodeBlock>> =
+        mutableListOf<MutableList<FencedCodeBlock>>()
+                .also { grouped ->
+                    forEach { block ->
+                        when {
+                            block.info.isNotBlank() -> grouped.add(mutableListOf(block))
+                            block.info.isBlank() -> grouped.lastOrNull()?.add(block)
+                        }
+                    }
+                }
+                .map { it.toList() }
+
+private fun List<List<FencedCodeBlock>>.toRows(): List<Row3<String, String, String>> = map { group ->
+    val lang = group.first().info
+    val script = group.first().literal
+    val output = when (group.size) {
+        1 -> group.first().literal
+                .lines()
+                .map { it.substringAfter("//", "") }
+                .filter { it.isNotBlank() }
+                .joinToString(separator = System.lineSeparator())
+        else -> group.drop(1).joinToString(separator = System.lineSeparator()) { it.literal }
+    }
+    Row3(lang, script, output)
+}
+
+private fun outputOf(block: () -> Unit): String {
+    val out = System.out
+    try {
+        val bytes = ByteArrayOutputStream()
+        System.setOut(PrintStream(bytes))
+
+        block.invoke()
+
+        return bytes.toString("UTF-8")
+    } finally {
+        System.setOut(out)
+    }
+}
+
+private fun String.nonBlankTrimmedLines(): List<String> = lines().map { it.trim() }.filter { it.isNotBlank() }

--- a/src/test/io/github/config4k/TestEnum.kt
+++ b/src/test/io/github/config4k/TestEnum.kt
@@ -3,7 +3,6 @@ package io.github.config4k
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
-
 class TestEnum : WordSpec({
     "Config.extract<Size>" should {
         "return SMALL" {

--- a/src/test/io/github/config4k/TestExtension.kt
+++ b/src/test/io/github/config4k/TestExtension.kt
@@ -100,6 +100,103 @@ class TestExtension : WordSpec({
             configValue.unwrapped() shouldBe b
         }
     }
+    "Config property delegate" should {
+        "return Int value" {
+            val num = 0
+            val config = ConfigFactory.parseString("""value = $num""")
+            val value: Int by config
+            value shouldBe num
+        }
+
+        "return String value" {
+            val str = "str"
+            val config = ConfigFactory.parseString("""value = $str""")
+            val value: String by config
+            value shouldBe str
+        }
+
+        "return Boolean value" {
+            val b = true
+            val config = ConfigFactory.parseString("""value = $b""")
+            val value: Boolean by config
+            value shouldBe b
+        }
+
+        "return Double value" {
+            val num = 0.1
+            val config = ConfigFactory.parseString("""value = $num""")
+            val value: Double by config
+            value shouldBe num
+        }
+
+        "return Float value" {
+            val num = 0.1f
+            val config = ConfigFactory.parseString("""value = $num""")
+            val value: Float by config
+            value shouldBe num
+        }
+
+        "return Long value" {
+            val num = 1000L
+            val config = ConfigFactory.parseString("""value = $num""")
+            val value: Long by config
+            value shouldBe num
+        }
+
+        "return ConfigMemorySize" {
+            val memorySize = "100KiB"
+            val config = ConfigFactory.parseString("""value = $memorySize""")
+            val value: ConfigMemorySize by config
+            value shouldBe ConfigMemorySize.ofBytes(100 * 1024)
+        }
+
+        "return Duration" {
+            val duration = "60minutes"
+            val config = ConfigFactory.parseString("""value = $duration""")
+            val value: Duration by config
+            value shouldBe Duration.ofMinutes(60)
+        }
+
+        "return Period" {
+            val period = "10years"
+            val config = ConfigFactory.parseString("""value = $period""")
+            val value: Period by config
+            value shouldBe Period.ofYears(10)
+        }
+
+        "return Regex" {
+            val regex = ".*"
+            val config = ConfigFactory.parseString("""value = "$regex"""")
+            val value: Regex by config
+            value.pattern shouldBe regex
+        }
+
+        "return TemporalAmount" {
+            val temporalAmount = "5weeks"
+            val config = ConfigFactory.parseString("""value = $temporalAmount""")
+            val value: TemporalAmount by config
+            value shouldBe Period.ofWeeks(5)
+        }
+
+        "return Config" {
+            val inner = """
+                        |{
+                        | field = value
+                        |}""".trimMargin()
+            val config = ConfigFactory.parseString(
+                    """nest = $inner""")
+            val nest: Config by config
+            nest shouldBe ConfigFactory.parseString(inner)
+        }
+
+        "return ConfigValue" {
+            val b = true
+            val config = ConfigFactory.parseString("value = $b")
+            val value: ConfigValue by config
+            value.valueType() shouldBe ConfigValueType.BOOLEAN
+            value.unwrapped() shouldBe b
+        }
+    }
 })
 
 fun String.toConfig(): Config = ConfigFactory.parseString(this.trimIndent())


### PR DESCRIPTION
Split suggested functionality into two extension functions
- ~~`config.getConfig(Any)` extension to navigate path based on parameter's class's simpleName~~ (surely too esoteric to my own usage)
- `config.getValue(..)` extension function to act as a Property Delegate
- Added test that README examples run with the expected output

Example usage from updated README:


```kotlin
val config = ConfigFactory.parseString("""
                                          |stringValue = hello
                                          |booleanValue = true
                                          |""".trimMargin())

val stringValue: String by config
println(stringValue) // hello

val nullableStringValue: String? by config
println(nullableStringValue) // null

val booleanValue: Boolean by config
println(booleanValue) // true
```

Closes #71